### PR TITLE
feat(readme): add semantic-release badge if .releaserc.json exists #300

### DIFF
--- a/src/generators/readme.ts
+++ b/src/generators/readme.ts
@@ -6,6 +6,9 @@ import { PackageConfig } from '../packageConfig';
 import { FsUtil } from '../utils/fsUtil';
 import { promisePool } from '../utils/promisePool';
 
+const badgeUrl =
+  '[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)';
+
 export async function generateReadme(config: PackageConfig): Promise<void> {
   return logger.function('generateReadme', async () => {
     const filePath = path.resolve(config.dirPath, 'README.md');
@@ -13,25 +16,20 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
 
     const useSemanticRelease = fs.existsSync(path.resolve(config.dirPath, '.releaserc.json'));
     if (useSemanticRelease) {
-      // TODO: READMEをパースして、
-      // [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-      // が存在するかどうかを確認する。
-      // 存在しなければ、 newContent の良い感じの場所に追記する。
-      // 良い感じの場所に追記することが少し難しそう。
-      const badgeUrl =
-        '[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)';
-      if (newContent.indexOf(badgeUrl) === -1) {
-        let inserted = false;
-        for (let i = 0; i + 1 < newContent.length; i++) {
-          if (newContent.substring(i, i + 2) === '##') {
-            inserted = true;
-            newContent = newContent.slice(0, i) + badgeUrl + '\n' + newContent.slice(i);
-            break;
-          }
-        }
-        if (!inserted) newContent = newContent + '\n' + badgeUrl + '\n';
+      if (newContent.includes(badgeUrl)) {
+        //既にbadgeがある場合には削除
+        const badgePos = newContent.indexOf(badgeUrl);
+        newContent = newContent.substring(0, badgePos) + newContent.substring(badgePos + badgeUrl.length);
       }
-      newContent = newContent + '';
+      let inserted = false;
+      for (let i = 0; i < newContent.length; i++) {
+        if (newContent[i] === '\n') {
+          inserted = true;
+          newContent = `${newContent.slice(0, i + 1)}${badgeUrl}\n${newContent.slice(i + 1)}`;
+          break;
+        }
+      }
+      if (!inserted) newContent = `${newContent}\n${badgeUrl}\n`;
     }
 
     await promisePool.run(() => FsUtil.generateFile(filePath, newContent));

--- a/src/generators/readme.ts
+++ b/src/generators/readme.ts
@@ -17,7 +17,7 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
     const useSemanticRelease = fs.existsSync(path.resolve(config.dirPath, '.releaserc.json'));
     if (useSemanticRelease) {
       if (newContent.includes(badgeUrl)) {
-        //既にbadgeがある場合には削除
+        // 既にbadgeがある場合は削除
         const badgePos = newContent.indexOf(badgeUrl);
         newContent = newContent.substring(0, badgePos) + newContent.substring(badgePos + badgeUrl.length);
       }

--- a/src/generators/readme.ts
+++ b/src/generators/readme.ts
@@ -18,6 +18,19 @@ export async function generateReadme(config: PackageConfig): Promise<void> {
       // が存在するかどうかを確認する。
       // 存在しなければ、 newContent の良い感じの場所に追記する。
       // 良い感じの場所に追記することが少し難しそう。
+      const badgeUrl =
+        '[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)';
+      if (newContent.indexOf(badgeUrl) === -1) {
+        let inserted = false;
+        for (let i = 0; i + 1 < newContent.length; i++) {
+          if (newContent.substring(i, i + 2) === '##') {
+            inserted = true;
+            newContent = newContent.slice(0, i) + badgeUrl + '\n' + newContent.slice(i);
+            break;
+          }
+        }
+        if (!inserted) newContent = newContent + '\n' + badgeUrl + '\n';
+      }
       newContent = newContent + '';
     }
 


### PR DESCRIPTION
Close #300 

| In coming                |
| ------------------------ |
| <img src="https://user-images.githubusercontent.com/52747166/186619303-32cba58b-3cf4-41b4-9cd3-ea42b63d8295.png" width="400"> |

README.mdをパースし、semantic-releaseバッジが無い場合に、最初のh2タグの直前にsemantic-releaseバッジを追加。h2タグが無い場合には最後に追加