### PR TITLE
feat: change add-issue-to-project trigger

### DIFF
--- a/src/generators/workflow.ts
+++ b/src/generators/workflow.ts
@@ -109,7 +109,7 @@ const workflows = {
     name: 'Add issue to github project',
     on: {
       issues: {
-        types: ['labeled'],
+        types: ['opened'],
       },
     },
     jobs: {


### PR DESCRIPTION
条件が `labeled` だと、projectラベルがついているissueの他のラベルに対しても実行されてしまう。
これにより、

1. projectラベルで実行されたactionによりGH Projectに追加される
2. 他のラベルで実行されたactionで「すでにGH Projectに追加されている」というエラーでactionが失敗になる

という挙動になってしまい鬱陶しいので、`opened` に条件を変更した。
ラベルを後から付け外ししたときに実行されないのは妥協する。