### PR TITLE
fix: delete deprecated cpu_arch

### DIFF
--- a/src/generators/workflow.ts
+++ b/src/generators/workflow.ts
@@ -368,4 +368,5 @@ function migrateJob(job: any): void {
     delete job.with['dot_env_path'];
   }
   delete job.with['ci_size'];
+  delete job.with['cpu_arch'];
 }


### PR DESCRIPTION
mitou-ml の `test.yml` に `cpu_arch` が[残っており](https://github.com/WillBooster/mitou-ml/blob/813f029f5db1ccece30d999f713d924fe71229b8/.github/workflows/test.yml#L13)、action実行時に[エラーになる](https://github.com/WillBooster/mitou-ml/actions/runs/4179448472/workflow)のを修正
```
The workflow is not valid. .github/workflows/test.yml (Line: 14, Col: 17): Invalid input, cpu_arch is not defined in the referenced workflow.
```
