### PR TITLE
feat: configure VSCode settings

### DIFF
--- a/src/generators/vscodeSettings.ts
+++ b/src/generators/vscodeSettings.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import merge from 'deepmerge';
+
+import { logger } from '../logger.js';
+import type { PackageConfig } from '../packageConfig.js';
+import { fsUtil } from '../utils/fsUtil.js';
+import { sortKeys } from '../utils/objectUtil.js';
+import { promisePool } from '../utils/promisePool.js';
+
+function excludeSetting(excludeFile: string): unknown {
+  return {
+    'files.watcherExclude': {
+      [excludeFile]: true,
+    },
+  };
+}
+
+export async function generateVscodeSettings(config: PackageConfig): Promise<void> {
+  return logger.functionIgnoringException('generateVscodeSettings', async () => {
+    try {
+      const filePath = path.resolve(config.dirPath, '.vscode', 'settings.json');
+      const existingContent = await fs.promises.readFile(filePath, 'utf8');
+      let settings = JSON.parse(existingContent);
+      settings = merge.all([settings, excludeSetting('**/node_modules/**')]);
+      if (config.depending.next) {
+        settings = merge.all([settings, excludeSetting('**/.next/**')]);
+      }
+      sortKeys(settings ?? {});
+      const newContent = JSON.stringify(settings, undefined, 2);
+      await promisePool.run(() => fsUtil.generateFile(filePath, newContent));
+    } catch {
+      // do nothing
+    }
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { generateReadme } from './generators/readme.js';
 import { generateReleaserc } from './generators/releaserc.js';
 import { generateRenovateJson } from './generators/renovaterc.js';
 import { generateTsconfig } from './generators/tsconfig.js';
+import { generateVscodeSettings } from './generators/vscodeSettings.js';
 import { generateWorkflows } from './generators/workflow.js';
 import { generateYarnrcYml } from './generators/yarnrc.js';
 import { setupLabels } from './github/label.js';
@@ -127,6 +128,9 @@ async function main(): Promise<void> {
       await generatePackageJson(config, rootConfig, argv.skipDeps);
 
       promises.push(generateLintstagedrc(config));
+      if (config.containingVscodeSettingsJson && config.containingPackageJson) {
+        promises.push(generateVscodeSettings(config));
+      }
       if (config.containingTypeScript || config.containingTypeScriptInPackages) {
         promises.push(generateTsconfig(config, rootConfig));
       }

--- a/src/packageConfig.ts
+++ b/src/packageConfig.ts
@@ -25,6 +25,7 @@ export interface PackageConfig {
   containingPomXml: boolean;
   containingPubspecYaml: boolean;
   containingTemplateYaml: boolean;
+  containingVscodeSettingsJson: boolean;
 
   containingJavaScript: boolean;
   containingTypeScript: boolean;
@@ -132,6 +133,7 @@ export async function getPackageConfig(dirPath: string): Promise<PackageConfig |
       containingPomXml: fs.existsSync(path.resolve(dirPath, 'pom.xml')),
       containingPubspecYaml: fs.existsSync(path.resolve(dirPath, 'pubspec.yaml')),
       containingTemplateYaml: fs.existsSync(path.resolve(dirPath, 'template.yaml')),
+      containingVscodeSettingsJson: fs.existsSync(path.resolve(dirPath, '.vscode', 'settings.json')),
       containingJavaScript: containsAny('{app,src,tests,scripts}/**/*.{cjs,mjs,js,jsx}', dirPath),
       containingTypeScript: containsAny('{app,src,tests,scripts}/**/*.{cts,mts,ts,tsx}', dirPath),
       containingJsxOrTsx: containsAny('{app,src,tests}/**/*.{t,j}sx', dirPath),


### PR DESCRIPTION
### 変更点
以下の条件を満たす時、VSCodeが`node_modules`フォルダや`.next`フォルダ内の変更を監視しないように設定し、VSCodeの動作軽量化を行います。
- 現在のディレクトリにおいて以下の全ての条件を満たす
  - `.vscode/settings.json`が存在する
  - `package.json`が存在する

### 補足
`.vscode/settings.json`に影響が出る最初のPRのため、控えめな更新適用条件を設定してあります。

close #465 
