### PR TITLE
fix: hide differences of generated files in GitHub

### DIFF
--- a/src/generators/gitattributes.ts
+++ b/src/generators/gitattributes.ts
@@ -13,6 +13,8 @@ const newContent = `* text=auto
 ${[...extensions.codeWith2IndentSize, ...extensions.codeWith4IndentSize, ...extensions.markdownLike]
   .map((ext) => `*.${ext} text eol=lf`)
   .join('\n')}
+
+dist/** linguist-generated=true
 `;
 
 export async function generateGitattributes(config: PackageConfig): Promise<void> {


### PR DESCRIPTION
see also 
- https://github.com/WillBoosterLab/judge/commit/a487e3de324c2b63cca295dd8b7d0e50a4861048
- https://github.com/WillBoosterLab/judge/commit/41ddf6495cfe15f00963b9e172fab961d4c8c5da

## Self Check

- [x] I've confirmed `All checks have passed` on PR page. (You may leave this box unchecked due to long workflows.)
  - PR title follows [Angular's commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
    - PR title doesn't have `WIP:`.
  - All tests are passed.
    - Test command (e.g., `yarn test`) is passed.
    - Lint command (e.g., `yarn lint`) is passed.
- [x] I've reviewed my changes on PR's diff view.
