### PR TITLE
feat: add test-command input to gen-pr workflows

### DIFF
--- a/src/generators/workflow.ts
+++ b/src/generators/workflow.ts
@@ -219,7 +219,6 @@ const workflows = {
         with: {
           'coding-tool': 'claude-code',
           'issue-number': '${{ github.event.issue.number || github.event.number }}',
-          'test-command': 'yarn|bun check-all-for-ai',
         },
         secrets: {
           CLAUDE_CODE_OAUTH_TOKEN: '${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
@@ -244,7 +243,6 @@ const workflows = {
         with: {
           'coding-tool': 'codex-cli',
           'issue-number': '${{ github.event.issue.number || github.event.number }}',
-          'test-command': 'yarn|bun check-all-for-ai',
         },
         secrets: {
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}',
@@ -269,7 +267,6 @@ const workflows = {
         with: {
           'coding-tool': 'gemini-cli',
           'issue-number': '${{ github.event.issue.number || github.event.number }}',
-          'test-command': 'yarn|bun check-all-for-ai',
         },
         secrets: {
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}',
@@ -429,6 +426,11 @@ function normalizeJob(config: PackageConfig, job: Job, kind: KnownKind): void {
     kind === 'gen-pr-gemini'
   ) {
     job.secrets['GH_TOKEN'] = config.isPublicRepo ? '${{ secrets.PUBLIC_GH_BOT_PAT }}' : '${{ secrets.GH_BOT_PAT }}';
+  }
+
+  // Set test-command for gen-pr workflows based on package manager
+  if (kind === 'gen-pr-claude' || kind === 'gen-pr-codex' || kind === 'gen-pr-gemini') {
+    job.with['test-command'] = config.isBun ? 'bun run check-all-for-ai' : 'yarn check-all-for-ai';
   }
   if (config.release.npm && (kind === 'release' || kind === 'test')) {
     job.secrets['NPM_TOKEN'] = '${{ secrets.NPM_TOKEN }}';

--- a/src/generators/workflow.ts
+++ b/src/generators/workflow.ts
@@ -219,6 +219,7 @@ const workflows = {
         with: {
           'coding-tool': 'claude-code',
           'issue-number': '${{ github.event.issue.number || github.event.number }}',
+          'test-command': 'yarn|bun check-all-for-ai',
         },
         secrets: {
           CLAUDE_CODE_OAUTH_TOKEN: '${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
@@ -243,6 +244,7 @@ const workflows = {
         with: {
           'coding-tool': 'codex-cli',
           'issue-number': '${{ github.event.issue.number || github.event.number }}',
+          'test-command': 'yarn|bun check-all-for-ai',
         },
         secrets: {
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}',
@@ -267,6 +269,7 @@ const workflows = {
         with: {
           'coding-tool': 'gemini-cli',
           'issue-number': '${{ github.event.issue.number || github.event.number }}',
+          'test-command': 'yarn|bun check-all-for-ai',
         },
         secrets: {
           GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}',


### PR DESCRIPTION
Add 'yarn|bun check-all-for-ai' as test-command input for all gen-pr workflows (claude, codex, gemini) to ensure comprehensive testing during PR generation.

Co-authored-by: WillBooster (Augment) <agent@willbooster.com>Close #<IssueNumber>

## Self Check

- [ ] I've confirmed `All checks have passed` on this page.
  - PR title follows [Angular's commit message format](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
  - PR title doesn't have `WIP:`.
  - The test command (e.g., `yarn test`) passed.
  - The lint command (e.g., `yarn lint`) passed.
  - You may leave this box unchecked due to long workflows.
- [ ] I've reviewed my changes on the GitHub diff view.
- [ ] I've written the steps to test my changes.
- [ ] I've added screenshots (if the UI changed).
  - You may leave this box unchecked if you didn't modify the UI.

<!-- Please add screenshots if you modify the UI.
| Current                  | In coming                |
| ------------------------ | ------------------------ |
| <img src="" width="400"> | <img src="" width="400"> |
-->

<!-- Please add steps to test your changes.
## Steps to Test

1. Open http://localhost-exercode.willbooster.net:3000/ja-JP/courses/_example/lessons/_example_a_plus_b/problems/_example_a_plus_b after login.
2. Select the language `C`.
3. Write the following code:
   ```c
   #include <stdio.h>

   int main(void) {
     int a, b;

     scanf("%d %d", &a, &b);
     printf("%d", a + b);
     return 0;
   }
   ```
4. Push `Submit` button.
5. ...
-->
