### PR TITLE
fix: clarify agent function ordering guidance

### DIFF
--- a/src/generators/agents.ts
+++ b/src/generators/agents.ts
@@ -85,7 +85,7 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
 - Design each module with high cohesion, grouping related functionality together.
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.
-- When adding new functions or classes, define them below any functions or classes that call them to maintain a clear top-down call order.
+- Place calling functions or classes in the file above the functions or classes they call to maintain a clear top-down order.
   - e.g. \`function caller() { callee(); } function callee() { ... }\`
 - Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
 - Prefer \`undefined\` over \`null\` unless explicitly required by APIs or libraries.

--- a/src/generators/agents.ts
+++ b/src/generators/agents.ts
@@ -86,6 +86,7 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.
 - When adding new functions or classes, define them below any functions or classes that call them to maintain a clear top-down call order.
+  - e.g. \`function caller() { callee(); } function callee() { ... }\`
 - Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
 - Prefer \`undefined\` over \`null\` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of \`join()\` with an array of strings.


### PR DESCRIPTION
## Summary

- Clarify the generated coding-style guidance for function ordering in agent instructions
- Add a concrete example showing the expected top-down caller-before-callee pattern
- Limit the change to the generated agent prompt text in `src/generators/agents.ts`

## Why

- The existing instruction was correct but abstract, which leaves room for inconsistent interpretation
- A short inline example makes the intended structure obvious without changing runtime behavior

## Testing

- `yarn check-for-ai`

## Notes

- No production logic changed; this updates generated instruction text only
