### PR TITLE
fix: drop restrictive typeRoots for package test types


### DIFF
--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -106,6 +106,9 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
       } else {
         delete newSettings.compilerOptions.types;
       }
+      if (shouldDeleteTypeRoots(mergedTypes)) {
+        delete newSettings.compilerOptions.typeRoots;
+      }
     } catch {
       // do nothing
     }
@@ -140,6 +143,10 @@ function normalizeExtends(value: TsConfigJson['extends']): string[] {
 function normalizeStringArray(value: string | string[] | undefined): string[] {
   if (!value) return [];
   return Array.isArray(value) ? value : [value];
+}
+
+function shouldDeleteTypeRoots(typeNames: string[]): boolean {
+  return typeNames.some((typeName) => typeName === 'cypress' || typeName.includes('/'));
 }
 
 function getGeneratedRootDir(config: PackageConfig): string | undefined {

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -140,9 +140,10 @@ function normalizeExtends(value: TsConfigJson['extends']): string[] {
   return Array.isArray(value) ? value : [value];
 }
 
-function normalizeStringArray(value: string | string[] | undefined): string[] {
-  if (!value) return [];
-  return Array.isArray(value) ? value : [value];
+function normalizeStringArray(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
 }
 
 function shouldDeleteTypeRoots(typeNames: string[]): boolean {

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -147,6 +147,8 @@ function normalizeStringArray(value: unknown): string[] {
 }
 
 function shouldDeleteTypeRoots(typeNames: string[]): boolean {
+  // Package subpaths and scoped packages are resolved from package ownership, so preserving
+  // user-defined typeRoots would hide those declarations instead of merging them in.
   return typeNames.some((typeName) => typeName === 'cypress' || typeName.includes('/'));
 }
 

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -106,7 +106,7 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
       } else {
         delete newSettings.compilerOptions.types;
       }
-      if (shouldDeleteTypeRoots(mergedTypes)) {
+      if (shouldDeleteTypeRoots(generatedTypes)) {
         delete newSettings.compilerOptions.typeRoots;
       }
     } catch {
@@ -147,8 +147,8 @@ function normalizeStringArray(value: unknown): string[] {
 }
 
 function shouldDeleteTypeRoots(typeNames: string[]): boolean {
-  // Package subpaths and scoped packages are resolved from package ownership, so preserving
-  // user-defined typeRoots would hide those declarations instead of merging them in.
+  // Only generated package-owned test types should trigger this. User-defined slash-based
+  // entries may intentionally rely on custom typeRoots and should be preserved as-is.
   return typeNames.some((typeName) => typeName === 'cypress' || typeName.includes('/'));
 }
 


### PR DESCRIPTION
## Summary
- stop preserving `compilerOptions.typeRoots` when generated test types require package-owned declarations such as `vitest/globals`
- ignore malformed non-string entries in existing `compilerOptions.types` instead of letting merged tsconfig generation crash at runtime
- document why scoped packages and package subpaths still require dropping `typeRoots`

## Why
- repositories that keep `typeRoots` while referencing package-owned test types can lose access to those declarations after `wbfy` rewrites `tsconfig.json`
- existing `tsconfig.json` files are user input, so the generator needs to tolerate invalid `types` values even though the TypeScript type says `string | string[]`
- excluding slash-based package names would reintroduce the same visibility problem for scoped packages and subpath exports

## Testing
- yarn check-for-ai
- yarn start /Users/exkazuu/ghq/github.com/WillBooster/moti-ai

## Notes
- addressed the valid review comment by hardening `normalizeStringArray`
- resolved repeated `@types/*` suggestions without code changes because the TypeScript docs describe `types` entries as package names like `node`/`jest`, while `typeRoots` still blocks package-owned declarations outside the configured folders
