### PR TITLE
fix: always ignore playwright cli artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .idea/AugmentWebviewStateStore.xml
 .idea/copilot.*
 .idea/copilot/chatSessions/
+.playwright-cli/
 .serena/
 .tmp/
 __generated__/

--- a/src/generators/gitignore.ts
+++ b/src/generators/gitignore.ts
@@ -20,6 +20,7 @@ const commonContent = `
 .idea/AugmentWebviewStateStore.xml
 .idea/copilot.*
 .idea/copilot/chatSessions/
+.playwright-cli/
 .serena/
 .tmp/
 __generated__/
@@ -91,7 +92,6 @@ packaged.yaml
     if (config.depending.playwrightTest) {
       headUserContent += `playwright-report/
 test-results/
-.playwright-cli/
 `;
     }
     if (rootConfig.depending.reactNative || config.depending.reactNative) {


### PR DESCRIPTION
## Summary
- add .playwright-cli/ to the common generated .gitignore entries
- remove the Playwright-only duplicate entry

## Verification
- yarn check-for-ai