### PR TITLE
fix: preserve bun run settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lodash.clonedeep": "4.5.0",
     "minimal-promise-pool": "6.0.1",
     "simple-git": "3.33.0",
+    "smol-toml": "1.6.1",
     "typescript": "5.9.3",
     "yargs": "18.0.0",
     "zod": "4.3.6"

--- a/src/generators/bunfig.ts
+++ b/src/generators/bunfig.ts
@@ -55,11 +55,12 @@ const minimumReleaseAgeExcludes = [
   'react-dom',
 ];
 
-const newContentWithExactTrue = `env = false
+const newContent = (existingContent: string | undefined): string => `env = false
 telemetry = false
 
+${extractRunSectionContainingBun(existingContent)}
 [install]
-exact = true
+exact = ${existingContent?.includes('exact = false') ? 'false' : 'true'}
 linker = "hoisted"
 minimumReleaseAge = 432000 # 5 days
 minimumReleaseAgeExcludes = [
@@ -67,15 +68,17 @@ ${minimumReleaseAgeExcludes.map((packageName) => `    "${packageName}",`).join('
 ]
 `;
 
-const newContentWithExactFalse = newContentWithExactTrue.replace('exact = true', 'exact = false');
-
 export async function generateBunfigToml(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateBunfigToml', async () => {
     const filePath = path.resolve(config.dirPath, 'bunfig.toml');
-    const content =
-      fs.existsSync(filePath) && fs.readFileSync(filePath, 'utf8').includes('exact = false')
-        ? newContentWithExactFalse
-        : newContentWithExactTrue;
+    const existingContent = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : undefined;
+    const content = newContent(existingContent);
     await promisePool.run(() => fsUtil.generateFile(filePath, content));
   });
+}
+
+function extractRunSectionContainingBun(content: string | undefined): string {
+  const runSectionMatch = content?.match(/^(\[run]\n(?:(?!^\[).*\n?)*)/m);
+  const runSection = runSectionMatch?.[1]?.trim();
+  return runSection && /^\s*bun\s*=.*/m.test(runSection) ? `${runSection}\n\n` : '';
 }

--- a/src/generators/bunfig.ts
+++ b/src/generators/bunfig.ts
@@ -103,5 +103,5 @@ function parseBunfigToml(content: string | undefined): BunfigToml | undefined {
 }
 
 function generateRunSection(bunfigToml: BunfigToml | undefined): string {
-  return typeof bunfigToml?.run?.bun === 'boolean' ? `[run]\nbun = ${bunfigToml.run.bun}\n\n` : '';
+  return typeof bunfigToml?.run?.bun === 'boolean' ? `[run]\nbun = ${bunfigToml.run.bun}\n` : '';
 }

--- a/src/generators/bunfig.ts
+++ b/src/generators/bunfig.ts
@@ -1,10 +1,21 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { parse } from 'smol-toml';
+
 import { logger } from '../logger.js';
 import type { PackageConfig } from '../packageConfig.js';
 import { fsUtil } from '../utils/fsUtil.js';
 import { promisePool } from '../utils/promisePool.js';
+
+interface BunfigToml {
+  install?: {
+    exact?: boolean;
+  };
+  run?: {
+    bun?: boolean;
+  };
+}
 
 const minimumReleaseAgeExcludes = [
   '@exercode/problem-utils',
@@ -55,18 +66,21 @@ const minimumReleaseAgeExcludes = [
   'react-dom',
 ];
 
-const newContent = (existingContent: string | undefined): string => `env = false
+const newContent = (existingContent: string | undefined): string => {
+  const bunfigToml = parseBunfigToml(existingContent);
+  return `env = false
 telemetry = false
 
-${extractRunSectionContainingBun(existingContent)}
+${generateRunSection(bunfigToml)}
 [install]
-exact = ${existingContent?.includes('exact = false') ? 'false' : 'true'}
+exact = ${bunfigToml?.install?.exact === false ? 'false' : 'true'}
 linker = "hoisted"
 minimumReleaseAge = 432000 # 5 days
 minimumReleaseAgeExcludes = [
 ${minimumReleaseAgeExcludes.map((packageName) => `    "${packageName}",`).join('\n')}
 ]
 `;
+};
 
 export async function generateBunfigToml(config: PackageConfig): Promise<void> {
   return logger.functionIgnoringException('generateBunfigToml', async () => {
@@ -77,8 +91,17 @@ export async function generateBunfigToml(config: PackageConfig): Promise<void> {
   });
 }
 
-function extractRunSectionContainingBun(content: string | undefined): string {
-  const runSectionMatch = content?.match(/^(\[run]\n(?:(?!^\[).*\n?)*)/m);
-  const runSection = runSectionMatch?.[1]?.trim();
-  return runSection && /^\s*bun\s*=.*/m.test(runSection) ? `${runSection}\n\n` : '';
+function parseBunfigToml(content: string | undefined): BunfigToml | undefined {
+  if (!content) {
+    return undefined;
+  }
+  try {
+    return parse(content) as BunfigToml;
+  } catch {
+    return undefined;
+  }
+}
+
+function generateRunSection(bunfigToml: BunfigToml | undefined): string {
+  return typeof bunfigToml?.run?.bun === 'boolean' ? `[run]\nbun = ${bunfigToml.run.bun}\n\n` : '';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10261,6 +10261,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"smol-toml@npm:1.6.1":
+  version: 1.6.1
+  resolution: "smol-toml@npm:1.6.1"
+  checksum: 10c0/511a78722f99c7616fdb46af708de3d7e81434b5a3d58061166da73f28bfc6cae4f0cd04683f60515b9c490cd10152fce72287c960b337419c0299cc1f0f2a22
+  languageName: node
+  linkType: hard
+
 "socks-proxy-agent@npm:^8.0.3":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
@@ -11486,6 +11493,7 @@ __metadata:
     prettier-plugin-java: "npm:2.8.1"
     semantic-release: "npm:25.0.3"
     simple-git: "npm:3.33.0"
+    smol-toml: "npm:1.6.1"
     sort-package-json: "npm:3.6.1"
     ts-node: "npm:10.9.2"
     type-fest: "npm:5.5.0"


### PR DESCRIPTION
## Summary
- Preserve existing `[run]` sections that contain `bun = ...` when generating `bunfig.toml`
- Keep the existing `exact = false` preservation behavior while generating install settings

## Verification
- yarn check-for-ai
- git diff --check