### PR TITLE
fix: update Gemini styleguide with agents extra

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -11,7 +11,3 @@
 - Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
 - Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
 - Prefer using a single template literal for prompts instead of `join()` with an array of strings.
-
-## How to Run
-
-Use `yarn start` to run `wbfy` on this repository.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,1 +1,17 @@
-日本語でレビューしてください。
+以下のコーディング規約を踏まえて、日本語でレビューしてください。
+
+## Coding Style
+
+- Simplify code as much as possible to eliminate redundancy.
+- Design each module with high cohesion, grouping related functionality together.
+  - Refactor existing large modules into smaller, focused modules when necessary.
+  - Create well-organized directory structures with low coupling and high cohesion.
+- Place calling functions in the file above the functions they call to maintain a clear top-down order.
+  - e.g. `function caller() { callee(); } function callee() { ... }`
+- Write comments that explain "why" rather than "what". Avoid stating what can be understood from the code itself.
+- Prefer `undefined` over `null` unless explicitly required by APIs or libraries.
+- Prefer using a single template literal for prompts instead of `join()` with an array of strings.
+
+## How to Run
+
+Use `yarn start` to run `wbfy` on this repository.

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-defaultSemverRangePrefix: ''
+defaultSemverRangePrefix: ""
 
 enableGlobalCache: true
 
@@ -9,16 +9,16 @@ nodeLinker: node-modules
 npmMinimalAgeGate: 5d
 
 npmPreapprovedPackages:
-  - '@exercode/*'
-  - '@willbooster/*'
+  - "@exercode/*"
+  - "@willbooster/*"
   - next
-  - '@next/*'
+  - "@next/*"
   - react
   - react-dom
 
 plugins:
   - checksum: d387bf474c315e463ddcbda77aabda9ba0b28ab3723fccccf40a310a3225d073963841bc255b2d2d8de9c1111548a7308b6af27eb31db57c75c4b9cb05aea73e
     path: .yarn/plugins/plugin-auto-install.cjs
-    spec: 'https://github.com/WillBooster/yarn-plugin-auto-install/releases/download/v2.0.7/index.cjs'
+    spec: "https://github.com/WillBooster/yarn-plugin-auto-install/releases/download/v2.0.7/index.cjs"
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,4 @@
-defaultSemverRangePrefix: ""
+defaultSemverRangePrefix: ''
 
 enableGlobalCache: true
 
@@ -9,16 +9,16 @@ nodeLinker: node-modules
 npmMinimalAgeGate: 5d
 
 npmPreapprovedPackages:
-  - "@exercode/*"
-  - "@willbooster/*"
+  - '@exercode/*'
+  - '@willbooster/*'
   - next
-  - "@next/*"
+  - '@next/*'
   - react
   - react-dom
 
 plugins:
   - checksum: d387bf474c315e463ddcbda77aabda9ba0b28ab3723fccccf40a310a3225d073963841bc255b2d2d8de9c1111548a7308b6af27eb31db57c75c4b9cb05aea73e
     path: .yarn/plugins/plugin-auto-install.cjs
-    spec: "https://github.com/WillBooster/yarn-plugin-auto-install/releases/download/v2.0.7/index.cjs"
+    spec: 'https://github.com/WillBooster/yarn-plugin-auto-install/releases/download/v2.0.7/index.cjs'
 
 yarnPath: .yarn/releases/yarn-4.13.0.cjs

--- a/src/generators/geminiConfig.ts
+++ b/src/generators/geminiConfig.ts
@@ -55,8 +55,9 @@ export async function generateGeminiConfig(config: PackageConfig, allConfigs: Pa
     });
 
     const extraContent = await fsUtil.readFileIgnoringError(agentsExtraPath);
+    const codingRuleExtraContent = extraContent?.trimStart().startsWith('#') ? undefined : extraContent;
     const styleguideContent = `以下のコーディング規約を踏まえて、日本語でレビューしてください。\n\n${generateAgentCodingStyle(allConfigs)}${
-      extraContent ? `\n\n${extraContent.trimEnd()}` : ''
+      codingRuleExtraContent ? `\n\n${codingRuleExtraContent.trimEnd()}` : ''
     }`;
 
     const promises = [

--- a/src/generators/geminiConfig.ts
+++ b/src/generators/geminiConfig.ts
@@ -59,10 +59,10 @@ export async function generateGeminiConfig(config: PackageConfig, allConfigs: Pa
       extraContent ? `\n\n${extraContent.trimEnd()}` : ''
     }`;
 
-    const promises = [promisePool.run(() => fsUtil.generateFile(configFilePath, yamlContent))];
-    if (!fs.existsSync(styleguideFilePath)) {
-      promises.push(promisePool.run(() => fsUtil.generateFile(styleguideFilePath, styleguideContent)));
-    }
+    const promises = [
+      promisePool.run(() => fsUtil.generateFile(configFilePath, yamlContent)),
+      promisePool.run(() => fsUtil.generateFile(styleguideFilePath, styleguideContent)),
+    ];
     await Promise.all(promises);
   });
 }

--- a/src/generators/packageJson.ts
+++ b/src/generators/packageJson.ts
@@ -618,32 +618,41 @@ async function updatePrivatePackages(jsonObj: PackageJson): Promise<void> {
   jsonObj.devDependencies = jsonObj.devDependencies ?? {};
   const packageNames = new Set([...Object.keys(jsonObj.dependencies), ...Object.keys(jsonObj.devDependencies)]);
   if (packageNames.has('@willbooster/auth') && !isWorkspacePackage(jsonObj, '@willbooster/auth')) {
+    const specifier = getExistingDependencySpecifier(jsonObj, '@willbooster/auth');
     delete jsonObj.devDependencies['@willbooster/auth'];
-    const commitHash = await getLatestCommitHash('WillBoosterLab', 'auth');
-    jsonObj.dependencies['@willbooster/auth'] = `git@github.com:WillBoosterLab/auth.git#${commitHash}`;
+    jsonObj.dependencies['@willbooster/auth'] = specifier ?? (await getLatestPrivatePackageSpecifier('auth'));
   }
   if (packageNames.has('@discord-bot/shared') && !isWorkspacePackage(jsonObj, '@discord-bot/shared')) {
+    const specifier = getExistingDependencySpecifier(jsonObj, '@discord-bot/shared');
     delete jsonObj.devDependencies['@discord-bot/shared'];
-    const commitHash = await getLatestCommitHash('WillBoosterLab', 'discord-bot');
-    jsonObj.dependencies['@discord-bot/shared'] = `git@github.com:WillBoosterLab/discord-bot.git#${commitHash}`;
+    jsonObj.dependencies['@discord-bot/shared'] = specifier ?? (await getLatestPrivatePackageSpecifier('discord-bot'));
   }
 
   if (packageNames.has('@willbooster/code-analyzer') && !isWorkspacePackage(jsonObj, '@willbooster/code-analyzer')) {
+    const specifier = getExistingDependencySpecifier(jsonObj, '@willbooster/code-analyzer');
     delete jsonObj.dependencies['@willbooster/code-analyzer'];
-    const commitHash = await getLatestCommitHash('WillBoosterLab', 'code-analyzer');
     jsonObj.devDependencies['@willbooster/code-analyzer'] =
-      `git@github.com:WillBoosterLab/code-analyzer.git#${commitHash}`;
+      specifier ?? (await getLatestPrivatePackageSpecifier('code-analyzer'));
   }
   if (packageNames.has('@willbooster/judge') && !isWorkspacePackage(jsonObj, '@willbooster/judge')) {
+    const specifier = getExistingDependencySpecifier(jsonObj, '@willbooster/judge');
     delete jsonObj.devDependencies['@willbooster/judge'];
-    const commitHash = await getLatestCommitHash('WillBoosterLab', 'judge');
-    jsonObj.dependencies['@willbooster/judge'] = `git@github.com:WillBoosterLab/judge.git#${commitHash}`;
+    jsonObj.dependencies['@willbooster/judge'] = specifier ?? (await getLatestPrivatePackageSpecifier('judge'));
   }
   if (packageNames.has('@willbooster/llm-proxy') && !isWorkspacePackage(jsonObj, '@willbooster/llm-proxy')) {
+    const specifier = getExistingDependencySpecifier(jsonObj, '@willbooster/llm-proxy');
     delete jsonObj.devDependencies['@willbooster/llm-proxy'];
-    const commitHash = await getLatestCommitHash('WillBoosterLab', 'llm-proxy');
-    jsonObj.dependencies['@willbooster/llm-proxy'] = `git@github.com:WillBoosterLab/llm-proxy.git#${commitHash}`;
+    jsonObj.dependencies['@willbooster/llm-proxy'] = specifier ?? (await getLatestPrivatePackageSpecifier('llm-proxy'));
   }
+}
+
+function getExistingDependencySpecifier(jsonObj: PackageJson, packageName: string): string | undefined {
+  return jsonObj.dependencies?.[packageName] ?? jsonObj.devDependencies?.[packageName];
+}
+
+async function getLatestPrivatePackageSpecifier(repo: string): Promise<string> {
+  const commitHash = await getLatestCommitHash('WillBoosterLab', repo);
+  return `git@github.com:WillBoosterLab/${repo}.git#${commitHash}`;
 }
 
 function isWorkspacePackage(jsonObj: PackageJson, packageName: string): boolean {

--- a/src/generators/packageJson.ts
+++ b/src/generators/packageJson.ts
@@ -618,36 +618,26 @@ async function updatePrivatePackages(jsonObj: PackageJson): Promise<void> {
   jsonObj.devDependencies = jsonObj.devDependencies ?? {};
   const packageNames = new Set([...Object.keys(jsonObj.dependencies), ...Object.keys(jsonObj.devDependencies)]);
   if (packageNames.has('@willbooster/auth') && !isWorkspacePackage(jsonObj, '@willbooster/auth')) {
-    const specifier = getExistingDependencySpecifier(jsonObj, '@willbooster/auth');
     delete jsonObj.devDependencies['@willbooster/auth'];
-    jsonObj.dependencies['@willbooster/auth'] = specifier ?? (await getLatestPrivatePackageSpecifier('auth'));
+    jsonObj.dependencies['@willbooster/auth'] = await getLatestPrivatePackageSpecifier('auth');
   }
   if (packageNames.has('@discord-bot/shared') && !isWorkspacePackage(jsonObj, '@discord-bot/shared')) {
-    const specifier = getExistingDependencySpecifier(jsonObj, '@discord-bot/shared');
     delete jsonObj.devDependencies['@discord-bot/shared'];
-    jsonObj.dependencies['@discord-bot/shared'] = specifier ?? (await getLatestPrivatePackageSpecifier('discord-bot'));
+    jsonObj.dependencies['@discord-bot/shared'] = await getLatestPrivatePackageSpecifier('discord-bot');
   }
 
   if (packageNames.has('@willbooster/code-analyzer') && !isWorkspacePackage(jsonObj, '@willbooster/code-analyzer')) {
-    const specifier = getExistingDependencySpecifier(jsonObj, '@willbooster/code-analyzer');
     delete jsonObj.dependencies['@willbooster/code-analyzer'];
-    jsonObj.devDependencies['@willbooster/code-analyzer'] =
-      specifier ?? (await getLatestPrivatePackageSpecifier('code-analyzer'));
+    jsonObj.devDependencies['@willbooster/code-analyzer'] = await getLatestPrivatePackageSpecifier('code-analyzer');
   }
   if (packageNames.has('@willbooster/judge') && !isWorkspacePackage(jsonObj, '@willbooster/judge')) {
-    const specifier = getExistingDependencySpecifier(jsonObj, '@willbooster/judge');
     delete jsonObj.devDependencies['@willbooster/judge'];
-    jsonObj.dependencies['@willbooster/judge'] = specifier ?? (await getLatestPrivatePackageSpecifier('judge'));
+    jsonObj.dependencies['@willbooster/judge'] = await getLatestPrivatePackageSpecifier('judge');
   }
   if (packageNames.has('@willbooster/llm-proxy') && !isWorkspacePackage(jsonObj, '@willbooster/llm-proxy')) {
-    const specifier = getExistingDependencySpecifier(jsonObj, '@willbooster/llm-proxy');
     delete jsonObj.devDependencies['@willbooster/llm-proxy'];
-    jsonObj.dependencies['@willbooster/llm-proxy'] = specifier ?? (await getLatestPrivatePackageSpecifier('llm-proxy'));
+    jsonObj.dependencies['@willbooster/llm-proxy'] = await getLatestPrivatePackageSpecifier('llm-proxy');
   }
-}
-
-function getExistingDependencySpecifier(jsonObj: PackageJson, packageName: string): string | undefined {
-  return jsonObj.dependencies?.[packageName] ?? jsonObj.devDependencies?.[packageName];
 }
 
 async function getLatestPrivatePackageSpecifier(repo: string): Promise<string> {

--- a/src/utils/willboosterConfigsUtil.ts
+++ b/src/utils/willboosterConfigsUtil.ts
@@ -2,11 +2,9 @@ import type { PackageConfig } from '../packageConfig.js';
 
 const ESLINT_CONFIG_PREFIX = '@willbooster/eslint-config-';
 const pinnedDependencySpecifiers = {
-  '@eslint/js': '9.39.4',
-  eslint: '^9',
-  // 1.22.0 is published without dist/, which breaks ESLint config resolution.
-  'eslint-plugin-sort-class-members': '1.22.1',
-  typescript: '^5',
+  '@eslint/js': '^9.39.4',
+  eslint: '^9.39.4',
+  typescript: '^5.9.3',
 } as const;
 
 export function shouldSkipWillboosterConfigsEslintPackage(config: PackageConfig): boolean {

--- a/src/utils/willboosterConfigsUtil.ts
+++ b/src/utils/willboosterConfigsUtil.ts
@@ -2,10 +2,10 @@ import type { PackageConfig } from '../packageConfig.js';
 
 const ESLINT_CONFIG_PREFIX = '@willbooster/eslint-config-';
 const pinnedDependencySpecifiers = {
-  '@eslint/js': '^9',
+  '@eslint/js': '9.39.4',
   eslint: '^9',
   // 1.22.0 is published without dist/, which breaks ESLint config resolution.
-  'eslint-plugin-sort-class-members': '1.21.0',
+  'eslint-plugin-sort-class-members': '1.22.1',
   typescript: '^5',
 } as const;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4584,11 +4584,11 @@ __metadata:
   linkType: hard
 
 "baseline-browser-mapping@npm:^2.10.12":
-  version: 2.10.15
-  resolution: "baseline-browser-mapping@npm:2.10.15"
+  version: 2.10.16
+  resolution: "baseline-browser-mapping@npm:2.10.16"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10c0/0bbcdefe842e79a1bcded41f7ffd6cca7a89edc035cfabae84ed80f19a0318de3f909ee64e184c39165cef12213eba89335745b101eeace2a4eaf290680d3af2
+  checksum: 10c0/9947243bb8f16db3f8e05397c5c3e7a91243dcf2d1ec6a681ad5ffabeadee36c1061cd18e5f0432088df6798fa0689890ba26db173b9ad23c5650709b7b2e7cf
   languageName: node
   linkType: hard
 
@@ -11285,8 +11285,8 @@ __metadata:
   linkType: hard
 
 "vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.0.4
-  resolution: "vite@npm:8.0.4"
+  version: 8.0.5
+  resolution: "vite@npm:8.0.5"
   dependencies:
     fsevents: "npm:~2.3.3"
     lightningcss: "npm:^1.32.0"
@@ -11337,7 +11337,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/28c840fd663acfc6c41720412e607e67e58166e399dc44b5d394372d34fb963f382a80dfb4741ba2b471f3bcbbc6901a137eb83dc1280854970d10ce78fa098b
+  checksum: 10c0/bfc22896b2661753c01c398a058f1859bdbd3ebe55f3d8505ab629b39e5f68790c0a6f55f8644b6692b0b9b8e210f698082ef9f4fd0d76509f4a46762fbfbba2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Regenerate `.gemini/styleguide.md` on each `wbfy` run, matching the agent instruction files.
- Include `AGENTS_EXTRA.md` in Gemini styleguide output only when it does not start with a Markdown heading, so non-coding-rule sections are excluded.
- Keep `wbfy` dependency pins current for `@eslint/js` and `eslint-plugin-sort-class-members` so applying `wbfy` does not reintroduce stale dependency changes.
- Always refresh supported private package dependencies to the latest `WillBoosterLab` commit specifier instead of preserving old git refs.

## Why
- Gemini styleguide generation should pick up coding-rule extras consistently.
- Heading-based `AGENTS_EXTRA.md` content, such as `## How to Run`, is not part of Gemini code review rules and should stay out of `.gemini/styleguide.md`.
- The `wbfy` application step exposed stale dependency specifiers that would otherwise downgrade or loosen existing maintenance updates.
- Private package git dependencies should not remain pinned to stale commits after `wbfy` runs.

## Testing
- `yarn check-for-ai`
- `yarn start /Users/exkazuu/ghq/github.com/WillBooster/wbfy`
- `$review-fix-all` second pass: Codex, Claude Code, and Gemini CLI reported no concerns
- `bunx @willbooster/agent-skills@latest check-pr-ci`
- `bunx @willbooster/agent-skills@latest list-pr-review-threads`
- pre-commit hook
- pre-push hook
