### PR TITLE
fix: infer rootDir from production sources

### DIFF
--- a/src/generators/agents.ts
+++ b/src/generators/agents.ts
@@ -85,7 +85,7 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
 ## Coding Style
 
 - Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
-- Simplify code as much as possible by eliminating redundancy.
+- Simplify code as much as possible to eliminate redundancy.
 - Design each module with high cohesion, grouping related functionality together.
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.

--- a/src/generators/agents.ts
+++ b/src/generators/agents.ts
@@ -84,7 +84,8 @@ export function generateAgentCodingStyle(allConfigs: PackageConfig[]): string {
   return `
 ## Coding Style
 
-- Simplify code as much as possible to eliminate redundancy.
+- Use camelCase for JavaScript and TypeScript files (or PascalCase for React components).
+- Simplify code as much as possible by eliminating redundancy.
 - Design each module with high cohesion, grouping related functionality together.
   - Refactor existing large modules into smaller, focused modules when necessary.
   - Create well-organized directory structures with low coupling and high cohesion.

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -153,8 +153,10 @@ function shouldDeleteTypeRoots(typeNames: string[]): boolean {
 }
 
 function getGeneratedRootDir(config: PackageConfig): string | undefined {
-  const rootDirCandidates = getRootDirCandidates(config);
-  const existingRootSourceDirs = rootDirCandidates.filter((dirName) =>
+  const existingIncludedDirs = getSrcDirs(config).filter((dirName) =>
+    fs.existsSync(path.resolve(config.dirPath, dirName))
+  );
+  const existingRootSourceDirs = getRootDirCandidates(config).filter((dirName) =>
     fs.existsSync(path.resolve(config.dirPath, dirName))
   );
 
@@ -167,18 +169,17 @@ function getGeneratedRootDir(config: PackageConfig): string | undefined {
         .some(
           (dirent) =>
             dirent.isDirectory() &&
-            rootDirCandidates.some((dirName) => fs.existsSync(path.resolve(packagesDirPath, dirent.name, dirName)))
+            getRootDirCandidates(config).some((dirName) =>
+              fs.existsSync(path.resolve(packagesDirPath, dirent.name, dirName))
+            )
         );
     if (hasSubPackageSources) {
-      return existingRootSourceDirs.length > 0 ? '.' : './packages';
+      return existingIncludedDirs.length > 0 ? '.' : './packages';
     }
   }
 
-  if (existingRootSourceDirs.length === 1) {
+  if (existingIncludedDirs.length === 1 && existingRootSourceDirs.length === 1) {
     return `./${existingRootSourceDirs[0]}`;
-  }
-  if (existingRootSourceDirs.length > 1) {
-    return '.';
   }
 }
 
@@ -187,7 +188,7 @@ function getRootDirCandidates(config: PackageConfig): string[] {
 }
 
 function shouldReplaceExistingRootDir(existingRootDir: string, generatedRootDir: string | undefined): boolean {
-  return existingRootDir === '.' && generatedRootDir !== undefined && generatedRootDir !== '.';
+  return existingRootDir === '.' && generatedRootDir !== '.';
 }
 
 function getGeneratedTypes(config: PackageConfig): string[] {

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -188,6 +188,8 @@ function getRootDirCandidates(config: PackageConfig): string[] {
 }
 
 function shouldReplaceExistingRootDir(existingRootDir: string, generatedRootDir: string | undefined): boolean {
+  // Mixed source/test tsconfigs must omit rootDir; otherwise src-only rootDir breaks typecheck,
+  // while "." changes library declaration output from dist/*.d.ts to dist/src/*.d.ts.
   return existingRootDir === '.' && generatedRootDir !== '.';
 }
 

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -92,7 +92,7 @@ export async function generateTsconfig(config: PackageConfig): Promise<void> {
           !dirPath.includes('@types') && !dirPath.includes('__tests__/') && !dirPath.includes('tests/')
       );
       newSettings.compilerOptions ??= {};
-      if (existingRootDir) {
+      if (existingRootDir && !shouldReplaceExistingRootDir(existingRootDir, generatedRootDir)) {
         newSettings.compilerOptions.rootDir = existingRootDir;
       } else if (generatedRootDir) {
         newSettings.compilerOptions.rootDir = generatedRootDir;
@@ -184,6 +184,10 @@ function getGeneratedRootDir(config: PackageConfig): string | undefined {
 
 function getRootDirCandidates(config: PackageConfig): string[] {
   return getSrcDirs(config).filter((dirName) => dirName !== 'scripts' && dirName !== 'test');
+}
+
+function shouldReplaceExistingRootDir(existingRootDir: string, generatedRootDir: string | undefined): boolean {
+  return existingRootDir === '.' && generatedRootDir !== undefined && generatedRootDir !== '.';
 }
 
 function getGeneratedTypes(config: PackageConfig): string[] {

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -153,6 +153,8 @@ function shouldDeleteTypeRoots(typeNames: string[]): boolean {
 }
 
 function getGeneratedRootDir(config: PackageConfig): string | undefined {
+  // Keep test and scripts in this list so mixed tsconfigs omit rootDir instead of
+  // generating a src-only rootDir that conflicts with the generated include globs.
   const existingIncludedDirs = getSrcDirs(config).filter((dirName) =>
     fs.existsSync(path.resolve(config.dirPath, dirName))
   );

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -153,12 +153,13 @@ function shouldDeleteTypeRoots(typeNames: string[]): boolean {
 }
 
 function getGeneratedRootDir(config: PackageConfig): string | undefined {
+  const rootDirCandidates = getRootDirCandidates(config);
   // Keep test and scripts in this list so mixed tsconfigs omit rootDir instead of
   // generating a src-only rootDir that conflicts with the generated include globs.
   const existingIncludedDirs = getSrcDirs(config).filter((dirName) =>
     fs.existsSync(path.resolve(config.dirPath, dirName))
   );
-  const existingRootSourceDirs = getRootDirCandidates(config).filter((dirName) =>
+  const existingRootSourceDirs = rootDirCandidates.filter((dirName) =>
     fs.existsSync(path.resolve(config.dirPath, dirName))
   );
 
@@ -171,9 +172,7 @@ function getGeneratedRootDir(config: PackageConfig): string | undefined {
         .some(
           (dirent) =>
             dirent.isDirectory() &&
-            getRootDirCandidates(config).some((dirName) =>
-              fs.existsSync(path.resolve(packagesDirPath, dirent.name, dirName))
-            )
+            rootDirCandidates.some((dirName) => fs.existsSync(path.resolve(packagesDirPath, dirent.name, dirName)))
         );
     if (hasSubPackageSources) {
       return existingIncludedDirs.length > 0 ? '.' : './packages';

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -159,9 +159,7 @@ function getGeneratedRootDir(config: PackageConfig): string | undefined {
   const existingIncludedDirs = getSrcDirs(config).filter((dirName) =>
     fs.existsSync(path.resolve(config.dirPath, dirName))
   );
-  const existingRootSourceDirs = rootDirCandidates.filter((dirName) =>
-    fs.existsSync(path.resolve(config.dirPath, dirName))
-  );
+  const existingRootSourceDirs = existingIncludedDirs.filter((dirName) => rootDirCandidates.includes(dirName));
 
   if (config.isRoot && config.doesContainSubPackageJsons) {
     const packagesDirPath = path.resolve(config.dirPath, 'packages');
@@ -191,7 +189,7 @@ function getRootDirCandidates(config: PackageConfig): string[] {
 function shouldReplaceExistingRootDir(existingRootDir: string, generatedRootDir: string | undefined): boolean {
   // Mixed source/test tsconfigs must omit rootDir; otherwise src-only rootDir breaks typecheck,
   // while "." changes library declaration output from dist/*.d.ts to dist/src/*.d.ts.
-  return existingRootDir === '.' && generatedRootDir !== '.';
+  return generatedRootDir === undefined || (existingRootDir === '.' && generatedRootDir !== '.');
 }
 
 function getGeneratedTypes(config: PackageConfig): string[] {

--- a/src/generators/tsconfig.ts
+++ b/src/generators/tsconfig.ts
@@ -153,7 +153,8 @@ function shouldDeleteTypeRoots(typeNames: string[]): boolean {
 }
 
 function getGeneratedRootDir(config: PackageConfig): string | undefined {
-  const existingRootSourceDirs = getSrcDirs(config).filter((dirName) =>
+  const rootDirCandidates = getRootDirCandidates(config);
+  const existingRootSourceDirs = rootDirCandidates.filter((dirName) =>
     fs.existsSync(path.resolve(config.dirPath, dirName))
   );
 
@@ -166,7 +167,7 @@ function getGeneratedRootDir(config: PackageConfig): string | undefined {
         .some(
           (dirent) =>
             dirent.isDirectory() &&
-            getSrcDirs(config).some((dirName) => fs.existsSync(path.resolve(packagesDirPath, dirent.name, dirName)))
+            rootDirCandidates.some((dirName) => fs.existsSync(path.resolve(packagesDirPath, dirent.name, dirName)))
         );
     if (hasSubPackageSources) {
       return existingRootSourceDirs.length > 0 ? '.' : './packages';
@@ -179,6 +180,10 @@ function getGeneratedRootDir(config: PackageConfig): string | undefined {
   if (existingRootSourceDirs.length > 1) {
     return '.';
   }
+}
+
+function getRootDirCandidates(config: PackageConfig): string[] {
+  return getSrcDirs(config).filter((dirName) => dirName !== 'scripts' && dirName !== 'test');
 }
 
 function getGeneratedTypes(config: PackageConfig): string[] {


### PR DESCRIPTION
## Summary

- Infer TypeScript `rootDir` from production source directories while excluding `test` and `scripts` from rootDir candidates.
- Keep mixed source/test/script tsconfigs from retaining an unsafe `rootDir` when a safe generated replacement cannot be inferred.
- Restore generated AGENTS coding-style wording to match the repository styleguide.

## Why

- `wbfy` previously added `rootDir: "."` for libraries that should emit declarations at `dist/index.d.ts` instead of `dist/src/index.d.ts`.
- Mixed tsconfigs still need `rootDir` omitted so generated include globs for `test` and `scripts` do not trigger TS6059.

## Testing

- `yarn check-for-ai`
- pre-commit hook
- pre-push hook
- GitHub Actions via `bunx @willbooster/agent-skills@latest check-pr-ci`
