### PR TITLE
fix: avoid extra blank line in Gemini styleguide

### DIFF
--- a/src/generators/geminiConfig.ts
+++ b/src/generators/geminiConfig.ts
@@ -57,7 +57,7 @@ export async function generateGeminiConfig(config: PackageConfig, allConfigs: Pa
     const extraContent = await fsUtil.readFileIgnoringError(agentsExtraPath);
     const codingRuleExtraContent = extraContent?.trimStart().startsWith('#') ? undefined : extraContent;
     const styleguideContent = `以下のコーディング規約を踏まえて、日本語でレビューしてください。\n\n${generateAgentCodingStyle(allConfigs)}${
-      codingRuleExtraContent ? `\n\n${codingRuleExtraContent.trimEnd()}` : ''
+      codingRuleExtraContent ? `\n${codingRuleExtraContent.trimEnd()}` : ''
     }`;
 
     const promises = [


### PR DESCRIPTION
## Summary
- avoid inserting an extra blank line before non-section AGENTS_EXTRA.md content in generated Gemini styleguides

## Verification
- yarn check-for-ai