### PR TITLE
fix: allow latest agent-runtime-kit installs

### DIFF
--- a/src/generators/bunfig.ts
+++ b/src/generators/bunfig.ts
@@ -61,6 +61,7 @@ const minimumReleaseAgeExcludes = [
   '@willbooster/shared-lib-node',
   '@willbooster/shared-lib-react',
   '@willbooster/wb',
+  'agent-runtime-kit',
   'next',
   'react',
   'react-dom',

--- a/src/generators/yarnrc.ts
+++ b/src/generators/yarnrc.ts
@@ -65,6 +65,7 @@ export async function generateYarnrcYml(config: PackageConfig): Promise<void> {
       // We believe we are safe
       '@exercode/*',
       '@willbooster/*',
+      'agent-runtime-kit',
       // To deal with CVE like https://nextjs.org/blog/CVE-2025-66478
       'next',
       '@next/*',


### PR DESCRIPTION
## Summary

- Add agent-runtime-kit to the Yarn npm preapproved packages list.
- Add agent-runtime-kit to the Bun minimum release age excludes list.

## Why

- The generated package-manager settings apply a 5-day npm release age gate.
- agent-runtime-kit needs to be installable at its latest published version without waiting for that gate.

## Testing

- yarn check-for-ai
